### PR TITLE
Fixed bento warning

### DIFF
--- a/measure
+++ b/measure
@@ -49,7 +49,7 @@ class Datadog(Measure):
     @staticmethod
     def get_config(path=CONFIG_FPATH):
         try:
-            config = yaml.load(open(path))['datadog']
+            config = yaml.safe_load(open(path))['datadog']
             assert config and config.get('metrics'), 'No metrics has been provided at path "datadog.metrics" ' \
                                                      'in file located at {}'.format(path)
             return config


### PR DESCRIPTION
Bento Output:

```
bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html  
     > measure:52                                                                     
     ╷                                                                                
   52│   config = yaml.load(open(path))['datadog']                                    
     ╵                                                                                
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().
```